### PR TITLE
Fixed groovy plugin apply order

### DIFF
--- a/common-plugin.gradle
+++ b/common-plugin.gradle
@@ -1,6 +1,6 @@
-apply plugin:"org.grails.grails-plugin"
 apply plugin: 'java-library'
 apply plugin: 'groovy'
+apply plugin: "org.grails.grails-plugin"
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'


### PR DESCRIPTION
Fixed error:
Script '/common-plugin.gradle' line: 3

* What went wrong:
A problem occurred evaluating script.
> Failed to apply plugin 'org.gradle.groovy'.
   > Cannot add task 'groovydoc' as a task with that name already exists.