### PR TITLE
fix: Set longer wait period for Sonatype transitioning

### DIFF
--- a/common-publishing.gradle
+++ b/common-publishing.gradle
@@ -44,8 +44,8 @@ if (isReleaseVersion) {
             }
         }
         transitionCheckOptions {
-             maxRetries.set(40)
-             delayBetween.set(java.time.Duration.ofMillis(2000))
+             maxRetries.set(60)
+             delayBetween.set(java.time.Duration.ofMillis(4000))
         }
     }
 }


### PR DESCRIPTION
Some projects (for example grails-gsp) that use common-publishing.gradle time-out waiting for Sonatype transitioning which make the build fail and the rest of the Github workflow to halt. This change should set enough time to prevent that.